### PR TITLE
Keep the empty string in a field

### DIFF
--- a/lib/my_obfuscate/postgres.rb
+++ b/lib/my_obfuscate/postgres.rb
@@ -10,7 +10,7 @@ class MyObfuscate
     # We wrap it in an array to keep it consistent with MySql bulk
     # obfuscation (multiple rows per insert statement)
     def rows_to_be_inserted(line)
-      row = line.split(/\t/)
+      row = line.split(/\t/, -1)
       row.last && row.last.strip!
 
       row.collect! do |value|

--- a/spec/my_obfuscate/postgres_spec.rb
+++ b/spec/my_obfuscate/postgres_spec.rb
@@ -10,6 +10,11 @@ describe MyObfuscate::Postgres do
       expect(helper.rows_to_be_inserted(line)).to eq([["1","2","3","4"]])
     end
 
+    it "preserves empty strings at the end of a line" do
+      line = "1	2	3	4	"
+      expect(helper.rows_to_be_inserted(line)).to eq([["1","2","3","4",""]])
+    end
+
     it 'ignores the newline character at the end of string' do
       line = "1	2	3	4\n"
       expect(helper.rows_to_be_inserted(line)).to eq([["1","2","3","4"]])


### PR DESCRIPTION
We ran into a problem with fields that contained an empty string which happened to be the last field on the line of a Postgres dump.

Calling `.split` on a string that ends with a tab discards that last empty string.
