### PR TITLE
Fix postgres end of copy regex and remove blank lines when truncating

### DIFF
--- a/lib/my_obfuscate/copy_statement_parser.rb
+++ b/lib/my_obfuscate/copy_statement_parser.rb
@@ -34,7 +34,8 @@ class MyObfuscate
 
           output_io.write line
         elsif inside_copy_statement
-          output_io.puts obfuscator.obfuscate_bulk_insert_line(line, current_table_name, current_columns)
+          obfuscated_line = obfuscator.obfuscate_bulk_insert_line(line, current_table_name, current_columns)
+          output_io.puts obfuscated_line unless obfuscated_line.empty?
         else
           output_io.write line
         end

--- a/lib/my_obfuscate/copy_statement_parser.rb
+++ b/lib/my_obfuscate/copy_statement_parser.rb
@@ -29,7 +29,7 @@ class MyObfuscate
           end
 
           output_io.write line
-        elsif line.match /\S*\.\n/
+        elsif line.match /^\\\.$/
           inside_copy_statement = false
 
           output_io.write line

--- a/spec/my_obfuscate_spec.rb
+++ b/spec/my_obfuscate_spec.rb
@@ -141,7 +141,20 @@ COPY some_table_to_keep (a, b) FROM stdin;
         expect(scaffold_output_string).not_to match(/:age\s+=>\s+:keep.+scaffold/)
       end
 
+      context "when dump contains a '.' at the end of the line" do
+        let(:dump) do
+          StringIO.new(<<-SQL)
+  COPY another_table (a, b, c, d) FROM stdin;
+  1	2	3	4
+  1	2	3	.
+  \.
+          SQL
+      end
+      it "should not fail if a insert statement ends in a '.''" do
+        expect(output_string).not_to match(/1\t2\t3\t\./)
+      end
     end
+  end
 
     describe "when using MySQL" do
       context "when there is nothing to obfuscate" do


### PR DESCRIPTION
We had a table where the last column often has '.' in it which was matching the regex causing all rows after it to be printed out.
Also when truncating a 3gb table having any thousands of empty lines in the output file was wasting a bit of space.

This pull request fixes a bug with the end of copy matching in postgres dumps 
and also stops it from outputting blank lines when truncating a table.

More info:
https://www.postgresql.org/docs/9.6/static/sql-copy.html
```End of data can be represented by a single line containing just backslash-period (\.). ```