### PR TITLE
Obfuscation problem for postgresql database dumps.

### DIFF
--- a/lib/my_obfuscate/copy_statement_parser.rb
+++ b/lib/my_obfuscate/copy_statement_parser.rb
@@ -29,7 +29,7 @@ class MyObfuscate
           end
 
           output_io.write line
-        elsif line.match /\S*\.\n/
+        elsif line.match /\\\.\n/
           inside_copy_statement = false
 
           output_io.write line

--- a/spec/my_obfuscate_spec.rb
+++ b/spec/my_obfuscate_spec.rb
@@ -46,6 +46,11 @@ COPY another_table (a, b, c, d) FROM stdin;
 COPY some_table_to_keep (a, b) FROM stdin;
 5	6
 \.
+
+COPY some_table_ending_with_dot (a, b) FROM stdin;
+some_data_obfuscated    some_data_obfuscate
+some_data_unobfuscated	somedata_unobfuscated.
+\.
         SQL
       end
 
@@ -60,7 +65,11 @@ COPY some_table_to_keep (a, b) FROM stdin;
             :id => {:type => :integer, :between => 2..9, :unless => :nil}
           },
           :another_table => :truncate,
-          :some_table_to_keep => :keep
+          :some_table_to_keep => :keep,
+          :some_table_ending_with_dot => {
+             :a => {:type => :string, :length => 8, :chars => MyObfuscate::USERNAME_CHARS},
+             :b => {:type => :string, :length => 8, :chars => MyObfuscate::USERNAME_CHARS},
+          }
         }).tap do |obfuscator|
           obfuscator.database_type = :postgres
         end
@@ -96,6 +105,10 @@ COPY some_table_to_keep (a, b) FROM stdin;
         scaffolder.scaffold(dump, output)
         output.rewind
         output.read
+      end
+
+      it "is able to obfuscate data with a dot in the end" do
+        expect(output_string).not_to include("some_data_unobfuscated")
       end
 
       it "is able to obfuscate single column tables" do


### PR DESCRIPTION
Fixes a problem I encountered while trying to obfuscate a postgresql database dump.

Postgresql ends batches of import data in its dumps with **\.**  on a single line. 
Currently however, the regular expression deciding to stop importing will also stop when it encounters lines that have a single dot as their last character. 
This would be the case for a line that has as as its last column value some data ending in a dot.

This way, you might end up with a partially obfuscated dump.

The small fix will specifically look for the **\.** occurence, which seems to work for me.