### PR TITLE
postgres: ignore obfuscate in function

### DIFF
--- a/lib/my_obfuscate/postgres.rb
+++ b/lib/my_obfuscate/postgres.rb
@@ -50,5 +50,9 @@ class MyObfuscate
       /^\s*INSERT INTO/i.match(line)
     end
 
+    def parse_function_statement(line)
+      /^\s*CREATE FUNCTION/i.match(line)
+    end
+
   end
 end

--- a/spec/my_obfuscate_spec.rb
+++ b/spec/my_obfuscate_spec.rb
@@ -148,6 +148,7 @@ COPY some_table_to_keep (a, b) FROM stdin;
 
         it "doesn't raise an error if it insert statements" do
           expect { output_string }.to_not raise_error RuntimeError
+          expect(output_string).to include "INSERT INTO some_table (email, name, something, age) VALUES ('','', '', 25);\n"
         end
 
         it "will not obfuscate data within a function" do


### PR DESCRIPTION
We shouldn't be touching the pg_dump for postgres functions, since it takes away from its purpose. I'm proposing we copy functions line-for-line and omit it from the obfuscation.

Refs issue https://github.com/mavenlink/my_obfuscate/issues/10