### PR TITLE
Replace `ffaker` with `faker`

### DIFF
--- a/lib/my_obfuscate.rb
+++ b/lib/my_obfuscate.rb
@@ -1,6 +1,6 @@
 require 'jcode' if RUBY_VERSION < '1.9'
 require 'digest/md5'
-require 'ffaker'
+require 'faker'
 require 'walker_method'
 
 # Class for obfuscating MySQL dumps. This can parse mysqldump outputs when using the -c option, which includes

--- a/lib/my_obfuscate/config_applicator.rb
+++ b/lib/my_obfuscate/config_applicator.rb
@@ -30,44 +30,41 @@ class MyObfuscate
         row[index.to_i] = case definition[:type]
           when :email
             md5 = Digest::MD5.hexdigest(rand.to_s)[0...5]
-            clean_quotes("#{FFaker::Internet.email}.#{md5}.example.com")
+            clean_quotes("#{Faker::Internet.email}.#{md5}.example.com")
           when :string
             random_string(definition[:length] || 30, definition[:chars] || SENSIBLE_CHARS)
           when :lorem
-            clean_bad_whitespace(clean_quotes(FFaker::Lorem.sentences(definition[:number] || 1).join(".  ")))
+            clean_bad_whitespace(clean_quotes(Faker::Lorem.sentences(number: definition[:number] || 1).join(" ")))
           when :like_english
             clean_quotes random_english_sentences(definition[:number] || 1)
           when :name
-            clean_quotes(FFaker::Name.name)
+            clean_quotes(Faker::Name.name)
           when :first_name
-            clean_quotes(FFaker::Name.first_name)
+            clean_quotes(Faker::Name.first_name)
           when :last_name
-            clean_quotes(FFaker::Name.last_name)
+            clean_quotes(Faker::Name.last_name)
           when :address
-            clean_quotes("#{FFaker::AddressUS.street_address}\\n#{FFaker::AddressUS.city}, #{FFaker::AddressUS.state_abbr} #{FFaker::AddressUS.zip_code}")
+            clean_quotes(Faker::Address.full_address)
           when :street_address
-            clean_bad_whitespace(clean_quotes(FFaker::AddressUS.street_address))
+            clean_bad_whitespace(clean_quotes(Faker::Address.street_address))
           when :secondary_address
-            clean_bad_whitespace(clean_quotes(FFaker::AddressUS.secondary_address))
+            clean_bad_whitespace(clean_quotes(Faker::Address.secondary_address))
           when :city
-            clean_quotes(FFaker::AddressUS.city)
+            clean_quotes(Faker::Address.city)
           when :state
-            clean_quotes FFaker::AddressUS.state_abbr
+            clean_quotes Faker::Address.state_abbr
           when :zip_code
-            FFaker::AddressUS.zip_code
+            Faker::Address.zip_code
           when :phone
-            clean_quotes FFaker::PhoneNumber.phone_number
+            clean_quotes Faker::PhoneNumber.phone_number
           when :company
-            clean_bad_whitespace(clean_quotes(FFaker::Company.name))
+            clean_bad_whitespace(clean_quotes(Faker::Company.name))
           when :ipv4
-            FFaker::Internet.ip_v4_address
+            Faker::Internet.ip_v4_address
           when :ipv6
-            # Inlined from FFaker because ffaker doesn't have ipv6.
-            @@ip_v6_space ||= (0..65535).to_a
-            container = (1..8).map{ |_| @@ip_v6_space.sample }
-            container.map{ |n| n.to_s(16) }.join(':')
+            Faker::Internet.ip_v6_address
           when :url
-            clean_bad_whitespace(FFaker::Internet.http_url)
+            clean_bad_whitespace(Faker::Internet.url)
           when :integer
             random_integer(definition[:between] || (0..1000)).to_s
           when :fixed

--- a/my_obfuscate.gemspec
+++ b/my_obfuscate.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/mavenlink/my_obfuscate}
   s.summary = %q{Standalone Ruby code for the selective rewriting of MySQL dumps in order to protect user privacy.}
 
-  s.add_dependency "ffaker"
+  s.add_dependency "faker"
   s.add_dependency "walker_method"
   s.add_development_dependency "rspec"
 

--- a/spec/my_obfuscate/config_applicator_spec.rb
+++ b/spec/my_obfuscate/config_applicator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'uri'
 
 describe MyObfuscate::ConfigApplicator do
 
@@ -7,7 +8,7 @@ describe MyObfuscate::ConfigApplicator do
       100.times do
         new_row = MyObfuscate::ConfigApplicator.apply_table_config(["blah", "something_else"], {:a => {:type => :email}}, [:a, :b])
         expect(new_row.length).to eq(2)
-        expect(new_row.first).to match(/^[\w\.]+\@(\w+\.){2,3}[a-f0-9]{5}\.example\.com$/)
+        expect(new_row.first).to match(URI::MailTo::EMAIL_REGEXP)
       end
     end
 
@@ -232,11 +233,11 @@ describe MyObfuscate::ConfigApplicator do
 
     describe "when faker generates values with quotes in them" do
       before do
-        allow(FFaker::Address).to receive(:city).and_return("O'ReillyTown")
-        allow(FFaker::Name).to receive(:name).and_return("Foo O'Reilly")
-        allow(FFaker::Name).to receive(:first_name).and_return("O'Foo")
-        allow(FFaker::Name).to receive(:last_name).and_return("O'Reilly")
-        allow(FFaker::Lorem).to receive(:sentences).with(any_args).and_return(["Foo bar O'Thingy"])
+        allow(Faker::Address).to receive(:city).and_return("O'ReillyTown")
+        allow(Faker::Name).to receive(:name).and_return("Foo O'Reilly")
+        allow(Faker::Name).to receive(:first_name).and_return("O'Foo")
+        allow(Faker::Name).to receive(:last_name).and_return("O'Reilly")
+        allow(Faker::Lorem).to receive(:sentences).with(any_args).and_return(["Foo bar O'Thingy"])
       end
 
       it "should remove single quotes from the value" do


### PR DESCRIPTION
In [`ffaker`'s words](https://github.com/ffaker/ffaker#why-ffaker)

> ffaker is a fork of faker, and was initially written in an effort to speed up a slow spec suite. Since those days faker has also been rewritten and the "speed" factor is probably irrelevant now.

We at @umts are replacing `ffaker` with `faker` ourselves on one of our applications that uses this library since speed is no longer a factor and `faker` has more dependents/is more actively maintained.

I noticed the usages of `ffaker` were relatively straightforward here, so I thought I'd offer this up.